### PR TITLE
Add pwr and fan as dedicated systemd services 

### DIFF
--- a/install-manjaro.sh
+++ b/install-manjaro.sh
@@ -91,48 +91,23 @@ Type=forking
 WantedBy=multi-user.target
 ' >> ${SERVICE_NAME}
 
-RC_SERVICE_NAME="/lib/systemd/system/rc.local.service"
-if [ -e $RC_SERVICE_NAME ]; then
-	sudo rm $RC_SERVICE_NAME -f
-fi
-sudo echo '[Unit]
-Description=/etc/rc.local Compatibility
-Documentation=man:systemd-rc-local-generator(8)
-ConditionFileIsExecutable=/etc/rc.local
-After=network.target
-
-[Service]
-Type=forking
-ExecStart=/etc/rc.local start
-TimeoutSec=0
-RemainAfterExit=yes
-GuessMainPID=no
-
-[Install]
-WantedBy=multi-user.target
-' >> ${RC_SERVICE_NAME}
-
 CUR_DIR=$(pwd)
 
 #####################################
-echo "#!/bin/sh -e
 
-/etc/x-c1-pwr.sh &
-python ${CUR_DIR}/fan.py &
-exit 0
-" > /etc/rc.local
+cp ${CUR_DIR}/x-c1-fan.service /lib/systemd/system/
+cp ${CUR_DIR}/x-c1-pwr.service /lib/systemd/system/
 
-sudo chmod +x /etc/rc.local
-sudo systemctl enable rc.local
 sudo systemctl enable pigpiod
+sudo systemctl enable x-c1-fan
+sudo systemctl enable x-c1-pwr
 
 #auto run naspi.sh
 sudo pigpiod
-python ${CUR_DIR}/fan.py &
+/usr/local/bin/fan.py &
 
 echo "The installation is complete."
 echo "Please run 'sudo reboot' to reboot the device."
 echo "NOTE:"
-echo "1. DON'T modify the name fold: $(basename ${CUR_DIR}), or the PWM fan will not work after reboot."
-echo "2. fan.py is python file to control fan speed according temperature of CPU, you can modify it according your needs."
-echo "3. PWM fan needs a PWM signal to start working. If fan doesn't work in third-party OS afer reboot only remove the YELLOW wire of fan to let the fan run immediately or contact us: info@geekworm.com."
+echo "1. /usr/local/bin/fan.py is python file to control fan speed according temperature of CPU, you can modify it according your needs."
+echo "2. PWM fan needs a PWM signal to start working. If fan doesn't work in third-party OS afer reboot only remove the YELLOW wire of fan to let the fan run immediately or contact us: info@geekworm.com."

--- a/install-manjaro.sh
+++ b/install-manjaro.sh
@@ -94,7 +94,8 @@ WantedBy=multi-user.target
 CUR_DIR=$(pwd)
 
 #####################################
-
+cp ${CUR_DIR}/fan.py /usr/local/bin/
+chmod +x /usr/local/bin/fan.py
 cp ${CUR_DIR}/x-c1-fan.service /lib/systemd/system/
 cp ${CUR_DIR}/x-c1-pwr.service /lib/systemd/system/
 

--- a/install-manjaro.sh
+++ b/install-manjaro.sh
@@ -4,17 +4,26 @@
 
 echo '#!/bin/bash
 
-SHUTDOWN=4
 REBOOTPULSEMINIMUM=200
 REBOOTPULSEMAXIMUM=600
-echo "$SHUTDOWN" > /sys/class/gpio/export
-echo "in" > /sys/class/gpio/gpio$SHUTDOWN/direction
-BOOT=17
-echo "$BOOT" > /sys/class/gpio/export
-echo "out" > /sys/class/gpio/gpio$BOOT/direction
-echo "1" > /sys/class/gpio/gpio$BOOT/value
 
-echo "Your device are shutting down..."
+SHUTDOWN=4
+if [ ! -d /sys/class/gpio/gpio$SHUTDOWN ]
+then
+  echo "$SHUTDOWN" > /sys/class/gpio/export
+  sleep 1 ;# Short delay while GPIO permissions are set up
+  echo "in" > /sys/class/gpio/gpio$SHUTDOWN/direction
+fi
+BOOT=17
+if [ ! -d /sys/class/gpio/gpio$BOOT ]
+then
+  echo "$BOOT" > /sys/class/gpio/export
+  sleep 1 ;# Short delay while GPIO permissions are set up
+  echo "out" > /sys/class/gpio/gpio$BOOT/direction
+  echo "1" > /sys/class/gpio/gpio$BOOT/value
+fi
+
+echo "Watching gpio for changes, to clean shutdown/reboot..."
 
 while [ 1 ]; do
   shutdownSignal=$(cat /sys/class/gpio/gpio$SHUTDOWN/value)

--- a/uninstall-manjaro.sh
+++ b/uninstall-manjaro.sh
@@ -5,15 +5,18 @@
 sudo systemctl stop pigpiod
 sudo systemctl disable pigpiod
 
-sudo systemctl stop rc.local
-sudo systemctl disable rc.local
+sudo systemctl stop x-c1-pwr
+sudo systemctl stop x-c1-fan
+sudo systemctl disable x-c1-pwr
+sudo systemctl disable x-c1-fan
 
 sudo rm /lib/systemd/system/pigpiod.service -f
-sudo rm /lib/systemd/system/rc.local.service -f
+sudo rm /lib/systemd/system/x-c1-pwr.service -f
+sudo rm /lib/systemd/system/x-c1-fan.service -f
 
 #sudo rm /etc/profile.d/naspi.sh -f
-sudo rm /etc/rc.local
 sudo sed -i '/x-c1/d' ~/.bashrc
 
 sudo rm /usr/local/bin/x-c1-softsd.sh -f
+sudo rm /usr/local/bin/fan.py -f
 sudo rm /etc/x-c1pwr.sh -f

--- a/x-c1-fan.service
+++ b/x-c1-fan.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run fan script xc-1
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/fan.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/x-c1-pwr.service
+++ b/x-c1-pwr.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run pwr daemon xc-1
+
+[Service]
+Type=simple
+ExecStart=/etc/x-c1-pwr.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Thank's for all I found it will be great to check journald for fan changes, also make fan.py live outside of home dir.
In this PR:
Move fan.py to /usr/local/bin.
Make fan.py more verbose
Dedicated services for pwr and fan
Check if gpio has been exported before exporting again to prevent errors when service restarted.