### PR TITLE
Make pigpio daemon bind to IPv4

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -66,6 +66,8 @@ echo "Your device will shutting down in 4 seconds..."
 echo "0" > /sys/class/gpio/gpio$BUTTON/value
 ' > /usr/local/bin/x-c1-softsd.sh
 sudo chmod +x /usr/local/bin/x-c1-softsd.sh
+
+sed -i '/ExecStart/ s/$/  -n 127.0.0.1/' /lib/systemd/system/pigpiod.service
 sudo systemctl enable pigpiod
 
 CUR_DIR=$(pwd)

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -5,6 +5,8 @@ sudo sed -i '/pigpiod/d' /etc/rc.local
 
 sudo sed -i '/x-c1/d' ~/.bashrc
 
+sed -i 's/ -n 127.0.0.1//' /lib/systemd/system/pigpiod.service
+
 sudo rm /usr/local/bin/x-c1-softsd.sh -f
 sudo rm /etc/x-c1-pwr.sh -f
 


### PR DESCRIPTION
Append `-n 127.0.0.1` to `ExecStart` line in
`/lib/systemd/system/pigpiod.service`
This fixes fan curve not working after boot on Raspberry Pi OS Lite.
`uninstall.sh` will remove that again.
Fixes #7 
I have not tested it any other OS.